### PR TITLE
Allow payment of variable shipping in FO

### DIFF
--- a/variableshipping/variableshipping.php
+++ b/variableshipping/variableshipping.php
@@ -178,7 +178,13 @@ class variableshipping extends CarrierModule
 	{
 		$context = Context::getContext();
 		if (!$context->employee || !$context->employee->id)
-			return false;
+		{
+			// allow in cart for checkout only if previously set (which is only possible via the BO)
+			if ( $context->cart->id_carrier != Configuration::get('VARIABLE_SHIPPING_CARRIER_ID') )
+			{
+				return false;
+			}
+		}
 
 		$value = file_get_contents(sys_get_temp_dir() . '/psvs-' . _DB_NAME_ . '-' . $params->id . '-' . $params->id_customer);
 		return $value ? round(floatval($value), 2) : 0.00;


### PR DESCRIPTION
This change enables variableshipping carrier in the FO so that payment can be made by the customer. This is safe because only a BO employee can add this carrier. Tested on PS 1.5.6.0

But, how to lock the cart or detect if more products have been added by the customer?
